### PR TITLE
Move dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify dependencies in gettext-setup.gemspex
+# Specify dependencies in gettext-setup.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'fast_gettext'
-gem 'gettext', ">= 3.0.2"
-
-gem 'rake', :require => false
-
-group :test do
-  gem 'rack-test'
-  gem 'rspec', '~> 2.13.0'
-  gem 'rspec-core', '~> 2.13.1'
-  gem 'rspec-expectations', '~> 2.13.0'
-  gem 'rspec-mocks', '~> 2.13.1'
-  gem 'simplecov'
-  gem 'webmock'
-end
+# Specify dependencies in gettext-setup.gemspex
+gemspec

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ These are the poingant bits of this example that you need to replicate in
 your project:
 
 1. Add `gem 'gettext-setup'` to your `Gemfile`.
-1. Add `gem 'fast_gettext'` to your `Gemfile`. This line is only needed
-   for running the bundled `rake` task.
 1. Copy `locales/config-sample.yaml` to your project and put it into a
 `locales` directory as `config.yaml`.
 1. Edit `locales/config.yaml` and make the necessary changes for your

--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -16,6 +16,18 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "gettext", ">= 3.0.2"
+  spec.add_dependency "fast_gettext"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+
+  spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "rspec", "~> 2.13.0"
+  spec.add_development_dependency "rspec-core", "~> 2.13.1"
+  spec.add_development_dependency "rspec-expectations", "~> 2.13.0"
+  spec.add_development_dependency "rspec-mocks", "~> 2.13.1"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "webmock"
+
 end


### PR DESCRIPTION
Before this commit, the gem works properly when working with the
source code, but encounters some problems with dependencies when
installing via rubygems.

This will move all dependencies into the gemspec and refer to the
gemspec from the Gemfile in order for the gem to work similarly when
run from source or as a gem.