### PR TITLE
Remove location comments from generated .pot file

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -34,7 +34,7 @@ namespace :gettext do
     copyright_holder = GettextSetup.config['copyright_holder']
     version=`git describe`
     system("rxgettext -o locales/#{project_name}.pot --no-wrap --sort-by-file " +
-           "--add-comments --msgid-bugs-address '#{bugs_address}' " +
+           "--no-location --add-comments --msgid-bugs-address '#{bugs_address}' " +
            "--package-name '#{package_name}' " +
            "--package-version '#{version}' " +
            "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " +


### PR DESCRIPTION
This change to the rake task (gettext:pot) removes the '#: FILE:LINE'
comments from the generated .pot file. The intent is to reduce churn
when the .pot file is under source control.