### PR TITLE
Pin fast_gettext version

### DIFF
--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "gettext", ">= 3.0.2"
-  spec.add_dependency "fast_gettext"
+  spec.add_dependency "fast_gettext", "~> 1.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
fast_gettext doesn't appear to know how to semver. fast_gettext
released a version 1.2.0 that requires ruby 2.1.0.