### PR TITLE
(INTL-8) Add a config option to exclude certain files from translation

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -17,9 +17,15 @@ namespace :gettext do
   end
 
   def files_to_translate
-    GettextSetup.config['source_files'].map do |p|
+    files = GettextSetup.config['source_files'].map do |p|
       Dir.glob(p)
     end.flatten
+    # check for optional list of files to exclude from string
+    # extraction
+    exclusions = (GettextSetup.config['exclude_files'] || []).map do |p|
+      Dir.glob(p)
+    end.flatten
+    files - exclusions
   end
 
   def pot_file_path


### PR DESCRIPTION
This commit allows the user to add an `exclude_files` field to the
config file, which contains a list of file paths to be excluded from
the files specified with the `source_files` option.