### PR TITLE
(INTL-9) Restrict extracted comments to those beginning with '#.'

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -40,7 +40,7 @@ namespace :gettext do
     copyright_holder = GettextSetup.config['copyright_holder']
     version=`git describe`
     system("rxgettext -o locales/#{project_name}.pot --no-wrap --sort-by-file " +
-           "--no-location --add-comments --msgid-bugs-address '#{bugs_address}' " +
+           "--no-location --add-comments=. --msgid-bugs-address '#{bugs_address}' " +
            "--package-name '#{package_name}' " +
            "--package-version '#{version}' " +
            "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " +


### PR DESCRIPTION
When no argument is passed to rxgettext's `--add-comments` flag, all
comments are extracted. We want to be able to restrict this to just
comments made for translators, so we pass '.' as the tag for translator
comments.