### PR TITLE
Allow restriction of extracted comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gettext-setup (0.10)
+    gettext-setup (0.11)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,21 @@ your project:
 `locales` directory as `config.yaml`.
 1. Edit `locales/config.yaml` and make the necessary changes for your
    project
-1. Add these three lines to your `Rakefile`:
+1. Add these three lines to your `Rakefile`, ensuring the `locales`
+   directory is found by the last line:
 ```
     spec = Gem::Specification.find_by_name 'gettext-setup'
     load "#{spec.gem_dir}/lib/tasks/gettext.rake"
     GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
 ```
-1. Add this line to the top of your `app.rb`:
+1. Add these lines at the start of your app (`app.rb` for server-side, the executable binary for CLI applications):
     `require 'gettext-setup'`
-1. Add these lines inside the class declared in your `app.rb`:
+    `GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))`
+    (Note that the second line may require modification to find the `locales` directory.
+1. For client-side applications, add this line:
+    `FastGettext.locale = GettextSetup.negotiate_locale(GettextSetup.candidate_locales)`
+1. For server-side applications, add these lines:
 ```
-    include FastGettext::Translation
-    GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
     before do
       FastGettext.locale = GettextSetup.negotiate_locale(env["HTTP_ACCEPT_LANGUAGE"])
     end

--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "gettext-setup"
-  spec.version       = "0.10"
+  spec.version       = "0.11"
   spec.authors       = ["Puppet"]
   spec.email         = ["info@puppet.com"]
   spec.description   = "A gem to ease i18n"

--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "gettext", ">= 3.0.2"
   spec.add_dependency "fast_gettext", "~> 1.1.0"
+  spec.add_dependency "locale"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "rspec-core", "~> 3.1"

--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 require 'fast_gettext'
 require 'yaml'
+require 'locale'
 
 module GettextSetup
   @@config = nil
@@ -32,6 +33,8 @@ module GettextSetup
     # Likewise, be explicit in our default language choice.
     FastGettext.default_locale = default_locale
     FastGettext.default_available_locales = locales
+
+    Locale.set_default(default_locale)
   end
 
   def self.locales_path
@@ -44,6 +47,12 @@ module GettextSetup
 
   def self.default_locale
     config['default_locale'] || "en"
+  end
+
+  # Returns the locale for the current machine. This is most useful for shell
+  # applications that need an ACCEPT-LANGUAGE header set.
+  def self.candidate_locales
+    Locale.candidates(type: :cldr).join(',')
   end
 
   def self.locales

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -34,13 +34,20 @@ namespace :gettext do
 
   desc "Update pot files"
   task :pot do
-    package_name = GettextSetup.config['package_name']
-    project_name = GettextSetup.config['project_name']
-    bugs_address = GettextSetup.config['bugs_address']
-    copyright_holder = GettextSetup.config['copyright_holder']
+    config = GettextSetup.config
+    package_name = config['package_name']
+    project_name = config['project_name']
+    bugs_address = config['bugs_address']
+    copyright_holder = config['copyright_holder']
+    # Done this way to allow the user to enter an empty string in the config.
+    if config.has_key?('comments_tag')
+      comments_tag = config['comments_tag']
+    else
+      comments_tag = 'TRANSLATORS'
+    end
     version=`git describe`
     system("rxgettext -o locales/#{project_name}.pot --no-wrap --sort-by-file " +
-           "--no-location --add-comments --msgid-bugs-address '#{bugs_address}' " +
+           "--no-location --add-comments#{comments_tag.to_s == '' ? '' : '=' + comments_tag} --msgid-bugs-address '#{bugs_address}' " +
            "--package-name '#{package_name}' " +
            "--package-version '#{version}' " +
            "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " +

--- a/locales/config-sample.yaml
+++ b/locales/config-sample.yaml
@@ -15,6 +15,10 @@ gettext:
   bugs_address: docs@puppetlabs.com
   # The holder of the copyright.
   copyright_holder: Puppet Labs, LLC.
+  # This determines which comments in code should be eligible for translation.
+  # Any comments that start with this string will be externalized. (Leave
+  # empty to include all.)
+  comments_tag: TRANSLATORS
   # Patterns for +Dir.glob+ used to find all files that might contain
   # translatable content, relative to the project root directory
   source_files:


### PR DESCRIPTION
When no argument is passed to rxgettext's `--add-comments` flag, all
comments are extracted. We want to be able to restrict this to just
comments made for translators, so we allow the user to supply a tag
using a new `comments_tag` config in the config.yaml. This tag will
default to "TRANSLATORS" if not supplied. If supplied but empty,
all comments will be extracted, affording us backwards-compatibility.

Fixes https://tickets.puppetlabs.com/browse/INTL-9