### PR TITLE
(INTL-13) Make update_pot task also replace POT when strings are deleted

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -62,12 +62,13 @@ namespace :gettext do
       old_pot = pot_file_path + ".old"
       File.rename(pot_file_path, old_pot)
       generate_new_pot
-      if system("msgcmp --use-untranslated '#{old_pot}' '#{pot_file_path}'")
-        puts "No string changes detected, keeping old POT file"
-        File.rename(old_pot, pot_file_path)
-      else
+      stdout, stderr, status = Open3.capture3("msgcmp --use-untranslated '#{old_pot}' '#{pot_file_path}'")
+      if status == 1 || /this message is not used/.match(stderr)
         File.delete(old_pot)
         puts "String changes detected, replacing with updated POT file"
+      else
+        puts "No string changes detected, keeping old POT file"
+        File.rename(old_pot, pot_file_path)
       end
     end
   end


### PR DESCRIPTION
Previously the update_pot rake task only replaced the POT file when
strings were added or changed, but not when they were deleted. This
commit updates the comparison logic to account for the warnings issued
by msgcmp when strings have been deleted, and act on them to replace the
POT file.