### PR TITLE
(INTL-14) do not send directories to rxgettext

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -26,7 +26,10 @@ namespace :gettext do
     exclusions = (GettextSetup.config['exclude_files'] || []).map do |p|
       Dir.glob(p)
     end.flatten
-    files - exclusions
+
+    # if file is a directory, take it out of the array. directories
+    # cause rxgettext to error out.
+    (files - exclusions).reject { |file| File.directory?(file) }
   end
 
   def pot_file_path


### PR DESCRIPTION
In modules, we would like the globs to be a little more flexible so we can set the source_files across all the modules instead of tailoring each one. This addition goes through the final translatable file list and removes directories, which cause rxgettext to error out if encountered.

```shell
Error parsing lib/puppet/type/acl
/Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/parser/glade.rb:27:in `readlines': Is a directory @ io_fillbuf - fd:7 lib/puppet/type/acl (Errno::EISDIR)
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/parser/glade.rb:27:in `target?'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:361:in `block in parse_path'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:360:in `each'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:360:in `parse_path'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:168:in `block in parse'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:166:in `each'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:166:in `parse'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:217:in `generate_pot'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:151:in `run'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/lib/gettext/tools/xgettext.rb:34:in `run'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/gettext-3.2.2/bin/rxgettext:24:in `<top (required)>'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/bin/rxgettext:23:in `load'
	from /Users/eric.putnam/.rbenv/versions/2.3.1/bin/rxgettext:23:in `<main>'
```