### PR TITLE
(INTL-18) default_available_locales as global variable

### DIFF
--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -5,6 +5,7 @@ require 'locale'
 
 module GettextSetup
   @@config = nil
+  FastGettext.default_available_locales = []
 
   # `locales_path` should include:
   # - config.yaml
@@ -32,7 +33,7 @@ module GettextSetup
 
     # Likewise, be explicit in our default language choice.
     FastGettext.default_locale = default_locale
-    FastGettext.default_available_locales = locales
+    FastGettext.default_available_locales = FastGettext.default_available_locales | locales
 
     Locale.set_default(default_locale)
   end

--- a/spec/fixtures/alt_locales/alt_locales.pot
+++ b/spec/fixtures/alt_locales/alt_locales.pot
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: alt_locales init-11-ga532a06\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2016-06-07 17:38-0500\n"
+"PO-Revision-Date: 2016-06-07 17:38-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures'))
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Hello, world!"
+msgstr ""

--- a/spec/fixtures/alt_locales/config.yaml
+++ b/spec/fixtures/alt_locales/config.yaml
@@ -1,0 +1,22 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'alt_locales'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more desctiptive than
+  # <project_name>
+  package_name: alt_locales
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppetlabs.com
+  # The holder of the copyright.
+  copyright_holder: Puppet Labs, LLC.
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'test_translation.rb'
+    - '../lib/**/*.rb'

--- a/spec/fixtures/alt_locales/jp/alt_locales.po
+++ b/spec/fixtures/alt_locales/jp/alt_locales.po
@@ -1,0 +1,23 @@
+# German translations for Sinatra i18n demo package.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Sinatra i18n demo \n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2016-04-05 10:39-0700\n"
+"PO-Revision-Date: 2016-02-26 18:21-0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: jp\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../app.rb:14
+msgid "Hello, world!"
+msgstr "こんにちは世界"
+

--- a/spec/lib/gettext_setup_spec.rb
+++ b/spec/lib/gettext_setup_spec.rb
@@ -51,4 +51,19 @@ describe GettextSetup do
       expect(GettextSetup.candidate_locales).to eq('de_DE,de,en')
     end
   end
+  context 'multiple locales' do
+    # locales/ loads the de locale and alt_locales/ loads the jp locale
+    before(:all) do
+      GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures', 'alt_locales'))
+    end
+    it 'can aggregate locales across projects' do
+      expect(FastGettext.default_available_locales).to include('en','de','jp')
+    end
+    it 'can switch to loaded locale' do
+      FastGettext.locale = GettextSetup.negotiate_locale('de')
+      expect(FastGettext.locale).to eq('de')
+      FastGettext.locale = GettextSetup.negotiate_locale('jp')
+      expect(FastGettext.locale).to eq('jp')
+    end
+  end
 end


### PR DESCRIPTION
Currently, available_locales is being overwritten every time a module is initialized with GettextSetup, so if we want a German translation, it is only be available if it is available in the most recent module that has been initialized (alphabetical order). This commit moves FastGettext.default_available locales to be initialized outside of the GettextSetup initialization and subsequently added to using a join every time a new project is processed by GettextSetup. This allows us to have a 'master' list of locales to choose from, which will contain all locales from all projects, instead of relying on the last initialized project to contain all the locales we might need. Spec tests include testing that a list is built when more than one project is initialized and that locales from that list can be set.