### PR TITLE
(INTL-17) Implement text_domain chaining

### DIFF
--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -5,6 +5,7 @@ require 'locale'
 
 module GettextSetup
   @@config = nil
+  @@translation_repositories = {}
   FastGettext.default_available_locales = []
 
   # `locales_path` should include:
@@ -25,11 +26,12 @@ module GettextSetup
     # Define our text domain, and set the path into our root.  I would prefer to
     # have something smarter, but we really want this up earlier even than our
     # config loading happens so that errors there can be translated.
-    FastGettext.add_text_domain(config['project_name'],
-                                :path => locales_path,
-                                :type => options[:file_format] || :po,
-                                :ignore_fuzzy => false)
-    FastGettext.default_text_domain = config['project_name']
+    add_repository_to_chain(config['project_name'], options)
+
+    # 'chain' is the only available multi-domain type in fast_gettext 1.1.0 We should consider
+    # investigating 'merge' once we can bump our dependency
+    FastGettext.add_text_domain('master_domain', type: :chain, chain: @@translation_repositories.values)
+    FastGettext.default_text_domain = 'master_domain'
 
     # Likewise, be explicit in our default language choice.
     FastGettext.default_locale = default_locale
@@ -38,12 +40,24 @@ module GettextSetup
     Locale.set_default(default_locale)
   end
 
+  def self.add_repository_to_chain(project_name,options)
+    repository = FastGettext::TranslationRepository.build(project_name,
+                                                          :path => locales_path,
+                                                          :type => options[:file_format] || :po,
+                                                          :ignore_fuzzy => false)
+    @@translation_repositories[project_name] = repository unless @@translation_repositories.key? project_name
+  end
+
   def self.locales_path
     @@locales_path
   end
 
   def self.config
     @@config ||= {}
+  end
+
+  def self.translation_repositories
+    @@translation_repositories
   end
 
   def self.default_locale

--- a/spec/lib/gettext_setup_spec.rb
+++ b/spec/lib/gettext_setup_spec.rb
@@ -66,4 +66,30 @@ describe GettextSetup do
       expect(FastGettext.locale).to eq('jp')
     end
   end
+  context 'translation repository chain' do
+    before(:all) do
+      GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures', 'alt_locales'))
+    end
+    it 'chain is not nil' do
+      expect(GettextSetup.translation_repositories).not_to be_nil
+    end
+    it 'can translate without switching text domains' do
+      FastGettext.locale = "de"
+      expect(_('Hello, world!')).to eq('Hallo, Welt!')
+      FastGettext.locale = "jp"
+      expect(_('Hello, world!')).to eq('こんにちは世界')
+    end
+    it 'does not allow duplicate repositories' do
+      GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures', 'alt_locales'))
+      repos = GettextSetup.translation_repositories
+      expect(repos.select { |k,v| k == 'alt_locales' }.size).to eq(1)
+    end
+    it 'does allow multiple unique domains' do
+      GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures', 'locales'))
+      repos = GettextSetup.translation_repositories
+      expect(repos.size) == 2
+      expect(repos.select { |k,v| k == 'alt_locales' }.size).to eq(1)
+      expect(repos.select { |k,v| k == 'sinatra-i18n' }.size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Instead of using individual text_domains, we will now be using a 'chain' which allows the continued use of \_() instead of switching to d\_() or D\_(). A chain will aggregate all the text domains into one master text domain so that we will no longer need to switch domains to find a translation.