### PR TITLE
(maint) Add minimum required ruby version

### DIFF
--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["spec/**/*"]
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 1.9.2'
+
   spec.add_dependency "gettext", ">= 3.0.2"
   spec.add_dependency "fast_gettext", "~> 1.1.0"
   spec.add_dependency "locale"


### PR DESCRIPTION
Since the fast_gettext version we use does not work with Ruby < 1.9.0, we
should add this dependency.