### PR TITLE
(INTL-20) Use first choice when negotiating locale

### DIFF
--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.2'
 
-  spec.add_dependency "gettext", ">= 3.0.2"
   spec.add_dependency "fast_gettext", "~> 1.1.0"
   spec.add_dependency "locale"
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "gettext", ">= 3.0.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", "~> 3.1"

--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -101,12 +101,12 @@ module GettextSetup
       pair[0] = FastGettext.default_locale if pair[0] == '*'
       pair
     end.sort_by do |(locale,qvalue)|
-      qvalue.to_f
+      -1 * qvalue.to_f
     end.select do |(locale,_)|
       FastGettext.available_locales.include?(locale)
     end
-    if available_locales and available_locales.last
-      available_locales.last.first
+    if available_locales and available_locales.first
+      available_locales.first.first
     else
       # We can't satisfy the request preference. Just use the default locale.
       default_locale

--- a/spec/lib/gettext_setup_spec.rb
+++ b/spec/lib/gettext_setup_spec.rb
@@ -45,7 +45,7 @@ describe GettextSetup do
   context 'clear' do
     it "can clear the locale" do
       expect(GettextSetup.default_locale).to eq('en')
-      expect(GettextSetup.candidate_locales).to eq('en_US,en')
+      expect(GettextSetup.candidate_locales).to include('en')
       GettextSetup.clear
       ENV['LANG'] = 'de_DE'
       expect(GettextSetup.candidate_locales).to eq('de_DE,de,en')

--- a/spec/lib/gettext_setup_spec.rb
+++ b/spec/lib/gettext_setup_spec.rb
@@ -31,6 +31,9 @@ describe GettextSetup do
       expect(GettextSetup.negotiate_locale('en;q=1, de;q=2')).to eq('de')
       expect(GettextSetup.negotiate_locale('en;q=1, de;q=0')).to eq('en')
     end
+    it "chooses the first value when q values are equal" do
+      expect(GettextSetup.negotiate_locale('de;q=1, en;q=1')).to eq('de')
+    end
   end
   context 'set_default_locale' do
     before :each do
@@ -60,7 +63,7 @@ describe GettextSetup do
       expect(FastGettext.default_available_locales).to include('en','de','jp')
     end
     it 'can switch to loaded locale' do
-      FastGettext.locale = GettextSetup.negotiate_locale('de')
+      FastGettext.locale = GettextSetup.negotiate_locale('de,en')
       expect(FastGettext.locale).to eq('de')
       FastGettext.locale = GettextSetup.negotiate_locale('jp')
       expect(FastGettext.locale).to eq('jp')


### PR DESCRIPTION
Locales are placed in preference order. If the `q` values are equal, past
behavior chose the last language in the header string, which will usually be
the default locale.

If `q` values are equal, the `negotiate_locale` method should choose the first
value in the list.