### PR TITLE
WIP - (MODULES-4640) - Generate metadata POT file and Rake Task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,8 @@ Style/MultilineBlockChain:
 Style/FileName:
   Exclude:
     - 'lib/gettext-setup.rb'
+
+Style/IndentHeredoc:
+  Exclude:
+    - 'lib/metadata_pot/metadata_pot.rb'
+

--- a/lib/generate_metadata_pot.rb
+++ b/lib/generate_metadata_pot.rb
@@ -1,0 +1,1 @@
+require 'metadata_pot/metadata_pot'

--- a/lib/metadata_pot/metadata_pot.rb
+++ b/lib/metadata_pot/metadata_pot.rb
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+
+def metadata_pot_file_path
+  File.join(locale_path, GettextSetup.config['project_name'] + '_metadata.pot')
+end
+
+def generate_new_pot_metadata
+  metadata = load_metadata_information
+  open(metadata_pot_file_path, 'w') do |f|
+    f << <<-DOC
+#
+#, fuzzy
+# msgid ""
+# msgstr ""
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: #{DateTime.now} \\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: Translate Toolkit 2.0.0\\n"
+#
+            DOC
+
+    if metadata.key?('summary')
+      f << <<-DOC
+#. metadata.json
+#: .summary
+msgid "#{metadata['summary']}"
+msgstr ""
+
+              DOC
+    end
+
+    if metadata.key?('description')
+      f << <<-DOC
+#. metadata.json
+#: .description
+msgid "#{metadata['description']}"
+msgstr ""
+
+              DOC
+    end
+  end
+end
+
+def load_metadata_information
+  metadata_file = 'metadata.json'
+  file = open(metadata_file)
+  json = file.read
+  JSON.parse(json)
+end

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -4,6 +4,7 @@
 #
 require_relative '../gettext-setup/gettext_setup'
 require_relative 'task_helper.rb'
+require_relative '../metadata_pot/metadata_pot'
 #
 # GettextSetup.initialize(File.absolute_path('locales', Dir.pwd))
 
@@ -31,6 +32,12 @@ namespace :gettext do
   task :pot do
     generate_new_pot
     puts "POT file #{pot_file_path} has been generated"
+  end
+
+  desc 'Generate POT file for metadata'
+  task :generate_metadata_pot do
+    generate_new_pot_metadata
+    puts "POT file #{metadata_pot_file_path} has been generated"
   end
 
   desc 'Update PO file for a specific language'


### PR DESCRIPTION
Using Ruby to generate a POT file for metadata.json. This also creates a rake task to generate the POT file. This will allow us to automate keeping the metadata.json POT file up to date.

This has been tested on tagmail and accounts. 