### PR TITLE
(INTL-25) ensure update_pot rake task detects string additions

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -63,7 +63,9 @@ namespace :gettext do
       generate_new_pot
       begin
         _, stderr, status = Open3.capture3("msgcmp --use-untranslated '#{old_pot}' '#{pot_file_path}'")
-        if status == 1 || /this message is not used/.match(stderr)
+        if status == 1 ||
+          /this message is not used/.match(stderr) || # strings have been deleted
+          /this message is used but not defined/.match(stderr) # strings have been added
           File.delete(old_pot)
           puts 'String changes detected, replacing with updated POT file'
         else

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -2,56 +2,12 @@
 # puts File.absolute_path('Gemfile', Dir.pwd)
 # Bundler.read_file(File.absolute_path('Gemfile', Dir.pwd))
 #
-require 'open3'
 require_relative '../gettext-setup/gettext_setup'
+require_relative 'task_helper.rb'
 #
 # GettextSetup.initialize(File.absolute_path('locales', Dir.pwd))
 
 namespace :gettext do
-  def locale_path
-    GettextSetup.locales_path
-  end
-
-  def text_domain
-    FastGettext.text_domain
-  end
-
-  def files_to_translate
-    files = GettextSetup.config['source_files'].map do |p|
-      Dir.glob(p)
-    end.flatten
-    # check for optional list of files to exclude from string
-    # extraction
-    exclusions = (GettextSetup.config['exclude_files'] || []).map do |p|
-      Dir.glob(p)
-    end.flatten
-
-    # if file is a directory, take it out of the array. directories
-    # cause rxgettext to error out.
-    (files - exclusions).reject { |file| File.directory?(file) }
-  end
-
-  def pot_file_path
-    File.join(locale_path, GettextSetup.config['project_name'] + '.pot')
-  end
-
-  def generate_new_pot
-    config = GettextSetup.config
-    package_name = config['package_name']
-    project_name = config['project_name']
-    bugs_address = config['bugs_address']
-    copyright_holder = config['copyright_holder']
-    # Done this way to allow the user to enter an empty string in the config.
-    comments_tag = config.key?('comments_tag') ? config['comments_tag'] : 'TRANSLATORS'
-    version = `git describe`
-    system("rxgettext -o locales/#{project_name}.pot --no-wrap --sort-by-file " \
-           "--add-comments#{comments_tag.to_s == '' ? '' : '=' + comments_tag} --msgid-bugs-address '#{bugs_address}' " \
-           "--package-name '#{package_name}' " \
-           "--package-version '#{version}' " \
-           "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " +
-           files_to_translate.join(' '))
-  end
-
   desc 'Generate a new POT file and replace old if strings changed'
   task :update_pot do
     if !File.exist? pot_file_path
@@ -61,20 +17,12 @@ namespace :gettext do
       old_pot = pot_file_path + '.old'
       File.rename(pot_file_path, old_pot)
       generate_new_pot
-      begin
-        _, stderr, status = Open3.capture3("msgcmp --use-untranslated '#{old_pot}' '#{pot_file_path}'")
-        if status == 1 ||
-          /this message is not used/.match(stderr) || # strings have been deleted
-          /this message is used but not defined/.match(stderr) # strings have been added
-          File.delete(old_pot)
-          puts 'String changes detected, replacing with updated POT file'
-        else
-          puts 'No string changes detected, keeping old POT file'
-          File.rename(old_pot, pot_file_path)
-        end
-      rescue IOError
-        # Ignore; probably means msgcmp isn't installed.
+      if string_changes?(old_pot, pot_file_path)
         File.delete(old_pot)
+        puts 'String changes detected, replacing with updated POT file'
+      else
+        puts 'No string changes detected, keeping old POT file'
+        File.rename(old_pot, pot_file_path)
       end
     end
   end

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -1,0 +1,58 @@
+require 'open3'
+
+def locale_path
+  GettextSetup.locales_path
+end
+
+def text_domain
+  FastGettext.text_domain
+end
+
+def files_to_translate
+  files = GettextSetup.config['source_files'].map do |p|
+    Dir.glob(p)
+  end.flatten
+  # check for optional list of files to exclude from string
+  # extraction
+  exclusions = (GettextSetup.config['exclude_files'] || []).map do |p|
+    Dir.glob(p)
+  end.flatten
+
+  # if file is a directory, take it out of the array. directories
+  # cause rxgettext to error out.
+  (files - exclusions).reject { |file| File.directory?(file) }
+end
+
+def pot_file_path
+  File.join(locale_path, GettextSetup.config['project_name'] + '.pot')
+end
+
+def generate_new_pot
+  config = GettextSetup.config
+  package_name = config['package_name']
+  project_name = config['project_name']
+  bugs_address = config['bugs_address']
+  copyright_holder = config['copyright_holder']
+  # Done this way to allow the user to enter an empty string in the config.
+  comments_tag = config.key?('comments_tag') ? config['comments_tag'] : 'TRANSLATORS'
+  version = `git describe`
+  system("rxgettext -o locales/#{project_name}.pot --no-wrap --sort-by-file " \
+         "--add-comments#{comments_tag.to_s == '' ? '' : '=' + comments_tag} --msgid-bugs-address '#{bugs_address}' " \
+         "--package-name '#{package_name}' " \
+         "--package-version '#{version}' " \
+         "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " +
+         files_to_translate.join(' '))
+end
+
+def string_changes?(old_pot, new_pot)
+  # Warnings will be in another language if locale is not set to en_US
+  _, stderr, status = Open3.capture3("LANG=en_US msgcmp --use-untranslated '#{old_pot}' '#{new_pot}'")
+  if status.exitstatus == 1 || /this message is not used/.match(stderr) || /this message is used but not defined/.match(stderr)
+    return true
+  end
+  return false
+rescue IOError
+  # probably means msgcmp is not present on the system
+  # so return true to be on the safe side
+  return true
+end

--- a/spec/fixtures/pot_update/add.pot
+++ b/spec/fixtures/pot_update/add.pot
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Sinatra i18n demo init-11-ga552a06\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2016-06-07 17:38-0500\n"
+"PO-Revision-Date: 2016-06-07 17:38-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures'))
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Hello, world!"
+msgstr ""
+
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Goodbye, world!"
+msgstr ""
+
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "new string"
+msgstr ""

--- a/spec/fixtures/pot_update/change.pot
+++ b/spec/fixtures/pot_update/change.pot
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Sinatra i18n demo init-11-ga552a06\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2016-06-07 17:38-0500\n"
+"PO-Revision-Date: 2016-06-07 17:38-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures'))
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Hello, world!"
+msgstr ""
+
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "changed string"
+msgstr ""

--- a/spec/fixtures/pot_update/non_string_changes.pot
+++ b/spec/fixtures/pot_update/non_string_changes.pot
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Sinatra i18n demo init-11-ga552a06\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2017-04-17 17:38-0500\n"
+"PO-Revision-Date: 2017-04-17 17:38-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures'))
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Hello, world!"
+msgstr ""
+
+#: ../../lib/different_file.rb:25
+msgid "Goodbye, world!"
+msgstr ""

--- a/spec/fixtures/pot_update/old.pot
+++ b/spec/fixtures/pot_update/old.pot
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Sinatra i18n demo init-11-ga552a06\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2016-06-07 17:38-0500\n"
+"PO-Revision-Date: 2016-06-07 17:38-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures'))
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Hello, world!"
+msgstr ""
+
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Goodbye, world!"
+msgstr ""

--- a/spec/fixtures/pot_update/remove.pot
+++ b/spec/fixtures/pot_update/remove.pot
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2016 Puppet Labs, LLC.
+# This file is distributed under the same license as the Sinatra i18n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Sinatra i18n demo init-11-ga552a06\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2016-06-07 17:38-0500\n"
+"PO-Revision-Date: 2016-06-07 17:38-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#. GettextSetup.initialize(File::join(File::dirname(File::dirname(__FILE__)), 'fixtures'))
+#: ../../lib/gettext_setup_spec.rb:25
+msgid "Hello, world!"
+msgstr ""

--- a/spec/lib/gettext_setup_spec.rb
+++ b/spec/lib/gettext_setup_spec.rb
@@ -1,6 +1,8 @@
 require 'rspec/expectations'
 require_relative '../spec_helper'
 
+require_relative '../../lib/gettext-setup'
+
 describe GettextSetup do
   before(:each) do
     GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'locales'))
@@ -50,8 +52,13 @@ describe GettextSetup do
       expect(GettextSetup.default_locale).to eq('en')
       expect(GettextSetup.candidate_locales).to include('en')
       GettextSetup.clear
-      ENV['LANG'] = 'de_DE'
-      expect(GettextSetup.candidate_locales).to eq('de_DE,de,en')
+      begin
+        old_locale = ENV['LANG']
+        ENV['LANG'] = 'de_DE'
+        expect(GettextSetup.candidate_locales).to eq('de_DE,de,en')
+      ensure
+        ENV['LANG'] = old_locale
+      end
     end
   end
   context 'multiple locales' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,10 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-require_relative '../lib/gettext-setup'
+def msgcmp_present?
+  # Try to call out to msgcmp, if it doesn't error, we have the tool
+  `msgcmp`
+  return true
+rescue IOError
+  return false
+end

--- a/spec/tasks/update_pot_spec.rb
+++ b/spec/tasks/update_pot_spec.rb
@@ -1,0 +1,28 @@
+require 'rspec/expectations'
+require_relative '../spec_helper.rb'
+
+require_relative '../../lib/tasks/task_helper.rb'
+
+describe 'string_changes?', if: msgcmp_present? do
+  old_pot = File.absolute_path('../fixtures/pot_update/old.pot', File.dirname(__FILE__))
+
+  it 'should detect string addition' do
+    new_pot = File.absolute_path('../fixtures/pot_update/add.pot', File.dirname(__FILE__))
+    expect(string_changes?(old_pot, new_pot)).to eq(true)
+  end
+
+  it 'should detect string removal' do
+    new_pot = File.absolute_path('../fixtures/pot_update/remove.pot', File.dirname(__FILE__))
+    expect(string_changes?(old_pot, new_pot)).to eq(true)
+  end
+
+  it 'should detect string changes' do
+    new_pot = File.absolute_path('../fixtures/pot_update/change.pot', File.dirname(__FILE__))
+    expect(string_changes?(old_pot, new_pot)).to eq(true)
+  end
+
+  it 'should not detect non-string changes' do
+    new_pot = File.absolute_path('../fixtures/pot_update/non_string_changes.pot', File.dirname(__FILE__))
+    expect(string_changes?(old_pot, new_pot)).to eq(false)
+  end
+end


### PR DESCRIPTION
The first commit adds an additional regex to the update_pot rake task, which
checks for the warning issued by `msgcmp` when it sees strings in the
new POT file which were not present in the old one. Previously it was
assumed `msgcmp` exited 1 in this case, but it does not, so the
additional grepping of stderr is necessary to detect string additions.

The second commit adds tests to make sure we can properly detect all the
different kinds (and absence) of POT file string changes. In order to
facilitate this testing, the helper methods around the `gettext` rake
tasks have been moved into their own file. Note that these new tests
are skipped if msgcmp is not present on the system.