### PR TITLE
Exit with status 1 when rake tasks fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Gemfile.lock
 
 # rspec coverage report
 coverage/
+
+# these will change each spec test run
+spec/fixtures/tmp_locales

--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -119,18 +119,22 @@ module GettextSetup
         puts 'No existing POT file, generating new'
         result = GettextSetup::Pot.generate_new_pot(locales_path, path)
         puts "POT file #{path} has been generated" if result
+        result
       else
         old_pot = path + '.old'
         File.rename(path, old_pot)
         result = GettextSetup::Pot.generate_new_pot(locales_path, path)
         if !result
           puts 'POT creation failed'
+          result
         elsif GettextSetup::Pot.string_changes?(old_pot, path)
-          File.delete(old_pot)
           puts 'String changes detected, replacing with updated POT file'
+          File.delete(old_pot)
+          true
         else
           puts 'No string changes detected, keeping old POT file'
           File.rename(old_pot, path)
+          true
         end
       end
     end

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -9,9 +9,11 @@ namespace :gettext do
 
   task :update_pot do
     begin
-      GettextSetup::Pot.update_pot
+      result = GettextSetup::Pot.update_pot
+      exit 1 unless result
     rescue GettextSetup::NoConfigFoundError => e
       puts e.message
+      exit 1
     end
   end
 
@@ -21,6 +23,8 @@ namespace :gettext do
       result = GettextSetup::Pot.generate_new_pot
       if result
         puts "POT file #{GettextSetup::Pot.pot_file_path} has been generated"
+      else
+        exit 1
       end
     rescue GettextSetup::NoConfigFoundError => e
       puts e.message
@@ -33,6 +37,8 @@ namespace :gettext do
       result = GettextSetup::MetadataPot.generate_metadata_pot
       if result
         puts "POT metadata file #{GettextSetup::MetadataPot.metadata_path} has been generated"
+      else
+        exit 1
       end
     rescue GettextSetup::NoConfigFoundError => e
       puts e.message
@@ -42,7 +48,8 @@ namespace :gettext do
   desc 'Update PO file for a specific language'
   task :po, [:language] do |_, args|
     begin
-      GettextSetup::Pot.generate_new_po(args.language)
+      result = GettextSetup::Pot.generate_new_po(args.language)
+      exit 1 unless result
     rescue GettextSetup::NoConfigFoundError => e
       puts e.message
     end

--- a/spec/lib/gettext-setup/gettext_setup_spec.rb
+++ b/spec/lib/gettext-setup/gettext_setup_spec.rb
@@ -1,11 +1,14 @@
 require 'rspec/expectations'
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
-require_relative '../../lib/gettext-setup'
+require_relative '../../../lib/gettext-setup'
 
 describe GettextSetup do
+  locales_path = File.absolute_path(File.join(File.dirname(__FILE__), '../../fixtures/locales'))
+  fixture_locales_path = File.absolute_path(File.join(File.dirname(__FILE__), '../../fixtures/fixture_locales'))
+
   before(:each) do
-    GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'locales'))
+    GettextSetup.initialize(locales_path)
   end
   let(:config) do
     GettextSetup.config
@@ -73,7 +76,7 @@ describe GettextSetup do
   context 'multiple locales' do
     # locales/ loads the de locale and fixture_locales/ loads the jp locale
     before(:all) do
-      GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'fixture_locales'))
+      GettextSetup.initialize(fixture_locales_path)
     end
     it 'can aggregate locales across projects' do
       expect(FastGettext.default_available_locales).to include('en')
@@ -89,7 +92,7 @@ describe GettextSetup do
   end
   context 'translation repository chain' do
     before(:all) do
-      GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'fixture_locales'))
+      GettextSetup.initialize(fixture_locales_path)
     end
     it 'chain is not nil' do
       expect(GettextSetup.translation_repositories).not_to be_nil
@@ -101,12 +104,12 @@ describe GettextSetup do
       expect(_('Hello, world!')).to eq('こんにちは世界')
     end
     it 'does not allow duplicate repositories' do
-      GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'fixture_locales'))
+      GettextSetup.initialize(fixture_locales_path)
       repos = GettextSetup.translation_repositories
       expect(repos.select { |k, _| k == 'fixture_locales' }.size).to eq(1)
     end
     it 'does allow multiple unique domains' do
-      GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'locales'))
+      GettextSetup.initialize(locales_path)
       repos = GettextSetup.translation_repositories
       expect(repos.size == 2)
       expect(repos.select { |k, _| k == 'fixture_locales' }.size).to eq(1)

--- a/spec/lib/gettext-setup/metadata_pot_spec.rb
+++ b/spec/lib/gettext-setup/metadata_pot_spec.rb
@@ -1,11 +1,11 @@
 require 'rspec/expectations'
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
-require_relative '../../lib/gettext-setup'
+require_relative '../../../lib/gettext-setup'
 
 describe GettextSetup::MetadataPot do
   before(:each) do
-    GettextSetup.initialize(File.join(File.dirname(File.dirname(__FILE__)), 'fixtures', 'locales'))
+    GettextSetup.initialize(File.absolute_path(File.join(File.dirname(__FILE__), '../../fixtures/locales')))
   end
   context '#metadata_path' do
     it 'finds the right metadata path' do

--- a/spec/lib/gettext-setup/pot_spec.rb
+++ b/spec/lib/gettext-setup/pot_spec.rb
@@ -1,42 +1,42 @@
 require 'rspec/expectations'
-require_relative '../spec_helper.rb'
+require_relative '../../spec_helper.rb'
 
-require_relative '../../lib/gettext-setup'
+require_relative '../../../lib/gettext-setup'
 describe GettextSetup::Pot do
   NoConfigFoundError = GettextSetup::NoConfigFoundError
 
   def fixture_locales_path
-    File.join(File.dirname(__FILE__), '../fixtures/fixture_locales')
+    File.join(File.dirname(__FILE__), '../../fixtures/fixture_locales')
   end
 
   def spec_locales_path
-    File.join(File.dirname(__FILE__), '../fixtures/spec_locales')
+    File.join(File.dirname(__FILE__), '../../fixtures/spec_locales')
   end
 
   def locales_path
-    File.join(File.dirname(__FILE__), '../fixtures/locales')
+    File.join(File.dirname(__FILE__), '../../fixtures/locales')
   end
 
   describe 'string_changes?', if: msgcmp_present? do
-    old_pot = File.absolute_path('../fixtures/string_changes/old.pot', File.dirname(__FILE__))
+    old_pot = File.absolute_path('../../fixtures/string_changes/old.pot', File.dirname(__FILE__))
 
     it 'should detect string addition' do
-      new_pot = File.absolute_path('../fixtures/string_changes/add.pot', File.dirname(__FILE__))
+      new_pot = File.absolute_path('../../fixtures/string_changes/add.pot', File.dirname(__FILE__))
       expect(GettextSetup::Pot.string_changes?(old_pot, new_pot)).to eq(true)
     end
 
     it 'should detect string removal' do
-      new_pot = File.absolute_path('../fixtures/string_changes/remove.pot', File.dirname(__FILE__))
+      new_pot = File.absolute_path('../../fixtures/string_changes/remove.pot', File.dirname(__FILE__))
       expect(GettextSetup::Pot.string_changes?(old_pot, new_pot)).to eq(true)
     end
 
     it 'should detect string changes' do
-      new_pot = File.absolute_path('../fixtures/string_changes/change.pot', File.dirname(__FILE__))
+      new_pot = File.absolute_path('../../fixtures/string_changes/change.pot', File.dirname(__FILE__))
       expect(GettextSetup::Pot.string_changes?(old_pot, new_pot)).to eq(true)
     end
 
     it 'should not detect non-string changes' do
-      new_pot = File.absolute_path('../fixtures/string_changes/non_string_changes.pot', File.dirname(__FILE__))
+      new_pot = File.absolute_path('../../fixtures/string_changes/non_string_changes.pot', File.dirname(__FILE__))
       expect(GettextSetup::Pot.string_changes?(old_pot, new_pot)).to eq(false)
     end
   end
@@ -44,16 +44,13 @@ describe GettextSetup::Pot do
   context 'generate_new_pot' do
     it "fails when GettextSetup can't find a config.yaml" do
       path = File.join(Dir.mktmpdir, 'empty.pot')
-      with_captured_stdout do
-        expect { GettextSetup::Pot.generate_new_pot(Dir.mktmpdir, path) }.to raise_error(NoConfigFoundError)
-      end
+      expect { GettextSetup::Pot.generate_new_pot(Dir.mktmpdir, path) }.to raise_error(NoConfigFoundError)
     end
     it 'builds a POT file' do
       path = File.join(Dir.mktmpdir, 'new.pot')
-      out = with_captured_stdout do
+      expect do
         GettextSetup::Pot.generate_new_pot(fixture_locales_path, path)
-      end
-      expect(out).to eq('') # STDOUT is determined in `update_pot`.
+      end.to output('').to_stdout # STDOUT is determined in `update_pot`.
       contents = File.read(path)
       expect(contents).to match(/Fixture locales/)
       expect(contents).to match(/docs@puppetlabs.com/)
@@ -66,43 +63,37 @@ describe GettextSetup::Pot do
     it "fails when GettextSetup can't find a config.yaml" do
       path = File.join(Dir.mktmpdir, 'fails.pot')
       po_path = File.join(Dir.mktmpdir, 'fails.po')
-      with_captured_stdout do
-        expect { GettextSetup::Pot.generate_new_po('ja', Dir.mktmpdir, path, po_path) }.to raise_error(NoConfigFoundError)
-      end
+      expect { GettextSetup::Pot.generate_new_po('ja', Dir.mktmpdir, path, po_path) }.to raise_error(NoConfigFoundError)
     end
     it 'complains when no language is supplied' do
-      stdout = with_captured_stdout do
-        GettextSetup::Pot.generate_new_po(nil, fixture_locales_path, Dir.mktmpdir, Dir.mktmpdir)
-      end
       result = "You need to specify the language to add. Either 'LANGUAGE=eo rake gettext:po' or 'rake gettext:po[LANGUAGE]'\n"
-      expect(stdout).to eq(result)
+      expect do
+        GettextSetup::Pot.generate_new_po(nil, fixture_locales_path, Dir.mktmpdir, Dir.mktmpdir)
+      end.to output(result).to_stdout
     end
     it 'generates new PO file', if: msginit_present? do
       po_path = File.join(Dir.mktmpdir, 'aa', 'tmp.po')
       pot_path = File.join(locales_path, 'sinatra-i18n.pot')
 
-      stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.generate_new_po('aa', locales_path, pot_path, po_path)
-      end
-      expect(stdout).to eq("PO file #{po_path} created\n")
+      end.to output("PO file #{po_path} created\n").to_stdout
     end
     it 'merges PO files', if: [msginit_present?, msgmerge_present?] do
       _('merged-po-file')
       po_path = File.join(Dir.mktmpdir, 'aa', 'tmp.po')
       pot_path = GettextSetup::Pot.pot_file_path
 
-      stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.generate_new_po('aa', fixture_locales_path, pot_path, po_path)
-      end
-      expect(stdout).to eq("PO file #{po_path} created\n")
+      end.to output("PO file #{po_path} created\n").to_stdout
       contents = File.read(po_path)
       expect(contents).to match(/msgid "Hello, world!"/)
 
       new_pot_path = File.join(spec_locales_path, 'sinatra-i18n.pot')
-      new_stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.generate_new_po('aa', spec_locales_path, new_pot_path, po_path)
-      end
-      expect(new_stdout).to eq("PO file #{po_path} merged\n")
+      end.to output("PO file #{po_path} merged\n").to_stdout
       new_contents = File.read(po_path)
       expect(new_contents).to match(/merged-po-file/)
     end
@@ -111,52 +102,45 @@ describe GettextSetup::Pot do
   context 'update_pot' do
     it "fails when GettextSetup can't find a config.yaml" do
       path = File.join(Dir.mktmpdir, 'fail-update.pot')
-      with_captured_stdout do
-        expect { GettextSetup::Pot.update_pot(Dir.mktmpdir, path) }.to raise_error(NoConfigFoundError)
-      end
+      expect { GettextSetup::Pot.update_pot(Dir.mktmpdir, path) }.to raise_error(NoConfigFoundError)
     end
     it 'creates POT when absent' do
       _('no-pot-file')
       path = File.join(Dir.mktmpdir, 'some-pot.pot')
-      stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.update_pot(spec_locales_path, path)
-      end
-      expect(stdout).to eq("No existing POT file, generating new\nPOT file #{path} has been generated\n")
+      end.to output("No existing POT file, generating new\nPOT file #{path} has been generated\n").to_stdout
       contents = File.read(path)
       expect(contents).to match(/msgid "no-pot-file"/)
     end
     it 'updates POT when something changes', if: [msginit_present?, msgmerge_present?] do
       _('some-spec-only-string')
       path = File.join(Dir.mktmpdir, 'some-pot.pot')
-      stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.update_pot(fixture_locales_path, path)
-      end
-      expect(stdout).to eq("No existing POT file, generating new\nPOT file #{path} has been generated\n")
+      end.to output("No existing POT file, generating new\nPOT file #{path} has been generated\n").to_stdout
       contents = File.read(path)
       expect(contents).to match(/Language-Team: LANGUAGE <LL@li.org>/)
       expect(contents).not_to match(/some-spec-only-string/)
-      output = with_captured_stdout do
+      expect do
         GettextSetup::Pot.update_pot(spec_locales_path, path)
-      end
+      end.to output("String changes detected, replacing with updated POT file\n").to_stdout
       new_contents = File.read(path)
       expect(new_contents).to match(/some-spec-only-string/)
-      expect(output).to eq("String changes detected, replacing with updated POT file\n")
     end
     it "doesn't update the POT when nothing changes", if: [msginit_present?, msgcmp_present?] do
       _('unchanged-string')
       path = File.join(Dir.mktmpdir, 'some-pot.pot')
-      stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.update_pot(spec_locales_path, path)
-      end
-      expect(stdout).to eq("No existing POT file, generating new\nPOT file #{path} has been generated\n")
+      end.to output("No existing POT file, generating new\nPOT file #{path} has been generated\n").to_stdout
       contents = File.read(path)
       expect(contents).to match(/unchanged-string/)
-      new_stdout = with_captured_stdout do
+      expect do
         GettextSetup::Pot.update_pot(spec_locales_path, path)
-      end
+      end.to output("No string changes detected, keeping old POT file\n").to_stdout
       new_contents = File.read(path)
       expect(new_contents).to eq(contents)
-      expect(new_stdout).to eq("No string changes detected, keeping old POT file\n")
     end
   end
 end

--- a/spec/lib/tasks/gettext_rake_spec.rb
+++ b/spec/lib/tasks/gettext_rake_spec.rb
@@ -1,0 +1,103 @@
+require 'rspec/expectations'
+require 'rake'
+require_relative '../../spec_helper.rb'
+
+load File.expand_path('../../../../lib/tasks/gettext.rake', __FILE__)
+
+describe 'gettext.rake' do
+  locales = File.expand_path('../../fixtures/locales', File.dirname(__FILE__))
+  tmp_locales = File.expand_path('../../fixtures/tmp_locales', File.dirname(__FILE__))
+  fixture_locales = File.expand_path('../../fixtures/fixture_locales', File.dirname(__FILE__))
+  tmp_pot_path = File.expand_path('sinatra-i18n.pot', tmp_locales)
+
+  before :each do
+    FileUtils.rm_r(tmp_locales, force: true)
+    FileUtils.cp_r(locales, tmp_locales)
+  end
+  after :each do
+    GettextSetup.clear
+    Rake::Task.tasks.each(&:reenable)
+  end
+  around :each do |test|
+    # Since we have `exit 1` in these rake tasks, we need to explicitly tell
+    # rspec that any unexpected errors aren't expected. Otherwise, if a
+    # SystemExit error is thrown, it just doesn't finish running the rest of
+    # the tests and considers the suite passing...
+    expect { test.run }.not_to raise_error
+  end
+  context Rake::Task['gettext:pot'] do
+    it 'outputs correctly' do
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to output(/POT file .+\/spec\/fixtures\/tmp_locales\/sinatra-i18n.pot has been generated/).to_stdout
+    end
+    it 'exits 1 on error' do
+      allow(GettextSetup::Pot).to receive(:generate_new_pot).and_return(false)
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to raise_error(SystemExit)
+    end
+  end
+  context Rake::Task['gettext:metadata_pot'] do
+    it 'outputs correctly' do
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to output(/POT metadata file .+sinatra-i18n_metadata.pot has been generated/).to_stdout
+    end
+    it 'exits 1 on error' do
+      allow(GettextSetup::MetadataPot).to receive(:generate_metadata_pot).and_return(false)
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to raise_error(SystemExit)
+    end
+  end
+  context Rake::Task['gettext:po'] do
+    it 'outputs correctly' do
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke('de')
+      end.to output(/PO file .+de\/sinatra-i18n.po merged/).to_stdout
+    end
+    it 'exits 1 on error' do
+      allow(GettextSetup::Pot).to receive(:generate_new_po).with('de').and_return(false)
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke('de')
+      end.to raise_error(SystemExit)
+    end
+  end
+  context Rake::Task['gettext:update_pot'] do
+    it 'does not update the POT when no changes are detected' do
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to output(/No string changes detected, keeping old POT file/).to_stdout
+    end
+    it 'can create a new POT' do
+      FileUtils.rm(tmp_pot_path)
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to output(/No existing POT file, generating new\nPOT file .+sinatra-i18n.pot has been generated/).to_stdout
+    end
+    it 'can update the POT' do
+      fixture_locales_pot = File.expand_path('fixture_locales.pot', fixture_locales)
+      FileUtils.cp(fixture_locales_pot, tmp_pot_path)
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to output(/String changes detected, replacing with updated POT file/).to_stdout
+    end
+    it 'exits 1 upon error' do
+      allow(GettextSetup::Pot).to receive(:update_pot).and_return(false)
+      expect do
+        GettextSetup.initialize(tmp_locales)
+        subject.invoke
+      end.to raise_error(SystemExit)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,12 +26,3 @@ end
 def msgmerge_present?
   cmd_present?('msgmerge')
 end
-
-def with_captured_stdout
-  old_stdout = $stdout
-  $stdout = StringIO.new('', 'w')
-  yield
-  $stdout.string
-ensure
-  $stdout = old_stdout
-end


### PR DESCRIPTION
Although the rake tasks would print out error messages indicating failure, the
tasks would still exit with status 0, meaning they wouldn't get proper
attention.

Fixes https://tickets.puppetlabs.com/browse/INTL-27