### PR TITLE
(maint) Require stdlib "tmpdir" providing Dir.mktmpdir

### DIFF
--- a/spec/lib/gettext-setup/metadata_pot_spec.rb
+++ b/spec/lib/gettext-setup/metadata_pot_spec.rb
@@ -1,4 +1,5 @@
 require 'rspec/expectations'
+require 'tmpdir'
 require_relative '../../spec_helper'
 
 require_relative '../../../lib/gettext-setup'

--- a/spec/lib/gettext-setup/pot_spec.rb
+++ b/spec/lib/gettext-setup/pot_spec.rb
@@ -1,4 +1,5 @@
 require 'rspec/expectations'
+require 'tmpdir'
 require_relative '../../spec_helper.rb'
 
 require_relative '../../../lib/gettext-setup'


### PR DESCRIPTION
Specs depend on Dir.mktmpdir for a few working directories, so the
stdlib file providing it should be required. Currently it's loaded only
as part of Bundler's own initialisation.