### PR TITLE
(maint) Remove unused rack-test, webmock dependencies

### DIFF
--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -25,12 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rspec-core', '~> 3.1'
   spec.add_development_dependency 'rspec-expectations', '~> 3.1'
   spec.add_development_dependency 'rspec-mocks', '~> 3.1'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
They appear to be leftovers from a sample Sinatra project, not used in
the current gem test suite.