### PR TITLE
When negotiating locale, only consider language, but not country variant

### DIFF
--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -112,6 +112,10 @@ module GettextSetup
     available_locales = accept_header.split(',').map do |locale|
       pair = locale.strip.split(';q=')
       pair << '1.0' unless pair.size == 2
+      # Ignore everything but the language itself; that means that we treat
+      # 'de' and 'de-DE' identical, and would use the 'de' message catalog
+      # for both.
+      pair[0] = pair[0].split('-')[0]
       pair[0] = FastGettext.default_locale if pair[0] == '*'
       pair
     end.sort_by do |(_, qvalue)|

--- a/spec/lib/gettext-setup/gettext_setup_spec.rb
+++ b/spec/lib/gettext-setup/gettext_setup_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'rspec/expectations'
 require_relative '../../spec_helper'
 
@@ -34,6 +35,10 @@ describe GettextSetup do
     it 'chooses the language with the highest q value' do
       expect(GettextSetup.negotiate_locale('en;q=1, de;q=2')).to eq('de')
       expect(GettextSetup.negotiate_locale('en;q=1, de;q=0')).to eq('en')
+    end
+    it 'ignores country variant' do
+      expect(GettextSetup.negotiate_locale('en;q=1, de-DE;q=2')).to eq('de')
+      expect(GettextSetup.negotiate_locale('en;q=1, de-DE;q=0')).to eq('en')
     end
     it 'chooses the first value when q values are equal' do
       expect(GettextSetup.negotiate_locale('de;q=1, en;q=1')).to eq('de')


### PR DESCRIPTION
When the Accept header contains something like 'de-DE', and we have 'en'
and 'de' available, we used to only look for a 'de-DE' message catalog, but
not for the more general 'de' catalog.

This patch makes it so that we drop country variant before looking for a
message catalog, i.e., we treat 'de-DE' and 'de' as exactly the same. This
will work as long as we do not need to have both a message catalog for the
language and one for that language respecting a variant.

Fixes https://tickets.puppetlabs.com/browse/ENTERPRISE-1060