### PR TITLE
Fix ordering of language var assignment from env

### DIFF
--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -72,10 +72,9 @@ module GettextSetup
     def self.generate_new_po(language, locales_path = GettextSetup.locales_path,
                              pot_file = nil, po_file = nil)
       GettextSetup.initialize(locales_path)
+      language ||= ENV['LANGUAGE']
       pot_file ||= GettextSetup::Pot.pot_file_path
       po_file ||= GettextSetup::Pot.po_file_path(language)
-
-      language ||= ENV['LANGUAGE']
 
       # Let's do some pre-verification of the environment.
       if language.nil?


### PR DESCRIPTION
Set the language variable from ENV['LANGUAGE'] before the variable
is used as an argument for the po_file_path method.