### PR TITLE
(PUP-7881) Put default locales at the front of available_locales

### DIFF
--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -98,7 +98,7 @@ module GettextSetup
     explicit = Dir.glob(File.absolute_path('*/*.po', locales_path)).map do |x|
       File.basename(File.dirname(x))
     end
-    (explicit + [default_locale]).uniq
+    ([default_locale] + explicit).uniq
   end
 
   # Given an HTTP Accept-Language header return the locale with the highest


### PR DESCRIPTION
FastGettext prefers the first item in its list of available locales when
choosing a locale before it has been set by the user. However, we were
putting our defaults at the end of the list we use to initialize
FastGettext, meaning FastGettext was choosing an essentially random
locale as its initial value for `locale`. This commit updates the way we
 construct our `available_locales` list to put the defaults first.