### PR TITLE
(FM-6323) - Copying Ruby POT rather than moving it

### DIFF
--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -156,7 +156,7 @@ module GettextSetup
       if File.exist? target_path
         FileUtils.mkdir_p(oldpot_dir)
         begin
-          FileUtils.mv(target_path, oldpot_path)
+          FileUtils.cp(target_path, oldpot_path)
         rescue
           raise "There was a problem creating .pot backup #{oldpot_path}, merge failed."
         end


### PR DESCRIPTION
When the Ruby POT file is moved, it doesn't exist in the repo when merging POT files. Copying means that it exists in the new location and also the Ruby strings are contained in the merged file.