### PR TITLE
(FM-6415) create header_only option for pot generation

### DIFF
--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -29,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-core', '~> 3.1'
   spec.add_development_dependency 'rspec-expectations', '~> 3.1'
   spec.add_development_dependency 'rspec-mocks', '~> 3.1'
-  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'fast_gettext'
 require 'yaml'
 require 'locale'

--- a/lib/gettext-setup/metadata_pot.rb
+++ b/lib/gettext-setup/metadata_pot.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'erb'
 require 'json'
 

--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -54,10 +54,18 @@ module GettextSetup
     #   The directory for the locales.
     # @param [:target_path] opts
     #   The output path for the new POT file.
+    # @param [:header_only] opts
+    #   Set to true to create a .pot file with only a header
     def self.generate_new_pot(opts = {})
       locales_path = opts[:locales_path] || GettextSetup.locales_path
       GettextSetup.initialize(locales_path)
       target_path = opts[:target_path] || pot_file_path
+      input_files = if opts[:header_only]
+                      tmpfile = Tempfile.new('gettext-setup.tmp')
+                      tmpfile.path
+                    else
+                      files_to_translate.join(' ')
+                    end
       config = GettextSetup.config
       package_name = config['package_name']
       bugs_address = config['bugs_address']
@@ -69,8 +77,9 @@ module GettextSetup
              "--add-comments#{comments_tag.to_s == '' ? '' : '=' + comments_tag} --msgid-bugs-address '#{bugs_address}' " \
              "--package-name '#{package_name}' " \
              "--package-version '#{version}' " \
-             "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " +
-             files_to_translate.join(' '))
+             "--copyright-holder='#{copyright_holder}' --copyright-year=#{Time.now.year} " \
+             "#{input_files}")
+      tmpfile.unlink if tmpfile
       $CHILD_STATUS.success?
     end
 

--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -1,7 +1,6 @@
-# -*- encoding: utf-8 -*-
-
 require 'open3'
 require 'English'
+require 'tempfile'
 
 module GettextSetup
   module Pot
@@ -166,8 +165,8 @@ module GettextSetup
         FileUtils.mkdir_p(oldpot_dir)
         begin
           FileUtils.cp(target_path, oldpot_path)
-        rescue
-          raise "There was a problem creating .pot backup #{oldpot_path}, merge failed."
+        rescue Errno::ENOENT => e
+          raise "There was a problem creating .pot backup #{oldpot_path}, merge failed: #{e.message}"
         end
         puts "Warning - #{target_filename} already exists and will be relocated to oldpot/old_#{target_filename}."
       end

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require_relative '../gettext-setup/gettext_setup'
 require_relative '../gettext-setup/pot'
 require_relative '../gettext-setup/metadata_pot'

--- a/spec/lib/gettext-setup/gettext_setup_spec.rb
+++ b/spec/lib/gettext-setup/gettext_setup_spec.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'rspec/expectations'
 require_relative '../../spec_helper'
 

--- a/spec/lib/gettext-setup/pot_spec.rb
+++ b/spec/lib/gettext-setup/pot_spec.rb
@@ -62,6 +62,18 @@ describe GettextSetup::Pot do
       expect(contents).to match(/Puppet, LLC/)
       expect(contents).to match(/test_strings.rb:1/)
     end
+    it 'builds a POT file with :header_only' do
+      path = File.join(Dir.mktmpdir, 'new.pot')
+      expect do
+        GettextSetup::Pot.generate_new_pot(locales_path: fixture_locales_path, target_path: path, header_only: true)
+      end.to output('').to_stdout # STDOUT is determined in `update_pot`
+      contents = File.read(path)
+      puts contents
+      expect(contents).to_not match(/Hello, world/)
+      expect(contents).to match(/Fixture locales/)
+      expect(contents).to match(/docs@puppetlabs.com/)
+      expect(contents).to match(/Puppet, LLC/)
+    end
   end
 
   context 'generate_new_po' do

--- a/spec/lib/gettext-setup/pot_spec.rb
+++ b/spec/lib/gettext-setup/pot_spec.rb
@@ -68,7 +68,6 @@ describe GettextSetup::Pot do
         GettextSetup::Pot.generate_new_pot(locales_path: fixture_locales_path, target_path: path, header_only: true)
       end.to output('').to_stdout # STDOUT is determined in `update_pot`
       contents = File.read(path)
-      puts contents
       expect(contents).to_not match(/Hello, world/)
       expect(contents).to match(/Fixture locales/)
       expect(contents).to match(/docs@puppetlabs.com/)
@@ -165,7 +164,7 @@ describe GettextSetup::Pot do
     before :all do
       { 'ruby' => 'ruby.pot', 'puppet' => 'puppet.pot', 'metadata' => 'metadata.pot' }.each do |pot_type, pot_name|
         File.open(File.join(merge_locales_path, pot_name), 'w') do |file|
-          file.write <<-EOF
+          file.write <<-POT
   # Copyright (C) 2017 Puppet, Inc.
   # This file is distributed under the same license as the puppetlabs-mysql package.
   # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
@@ -187,7 +186,7 @@ describe GettextSetup::Pot do
   #: ../lib/puppet/parser/functions/mysql_strip_hash.rb:11
   msgid "this is a #{pot_type} string"
   msgstr ""
-        EOF
+        POT
         end
       end
     end


### PR DESCRIPTION
for the sake of consistency across POT files (ruby, puppet, metadata), it seems to make sense for the headers to all be created in one place. This change allows for the creation of 'blank' POT files, or POT files with only a header, by passing in a blank input file. This provides the following benefits:
- When POT files are merged, differences in header content can cause a lot of clutter in the final POT file. identical headers will cut down on this clutter substantially.
- The generate function can be used to create blank POT files to allow for the appending of POT files for other languages in the future
- Consistency is great
- GettextSetup knows a lot about the current project so it can provide header info that other libraries may not be able to, like project name, etc.