### PR TITLE
(INTL-31) Refactor rake tasks to not setup FastGettext runtime

### DIFF
--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -21,11 +21,7 @@ module GettextSetup
   # valid `options` fields:
   # :file_format - one of the supported backends for fast_gettext (e.g. :po, :mo, :yaml, etc.)
   def self.initialize(locales_path = 'locales', options = {})
-    config_path = File.absolute_path('config.yaml', locales_path)
-    File.exist?(config_path) || raise(NoConfigFoundError, config_path)
-
-    @config = YAML.load_file(config_path)['gettext']
-    @locales_path = locales_path
+    GettextSetup.initialize_config(locales_path)
 
     # Make the translation methods available everywhere
     Object.send(:include, FastGettext::Translation)
@@ -45,6 +41,18 @@ module GettextSetup
     FastGettext.default_available_locales = FastGettext.default_available_locales | locales
 
     Locale.set_default(default_locale)
+  end
+
+  # Sets up the config class variables.
+  #
+  # Call this without calling initialize when you only need to deal with the
+  # translation files and you don't need runtime translation.
+  def self.initialize_config(locales_path = 'locales')
+    config_path = File.absolute_path('config.yaml', locales_path)
+    File.exist?(config_path) || raise(NoConfigFoundError, config_path)
+
+    @config = YAML.load_file(config_path)['gettext']
+    @locales_path = locales_path
   end
 
   def self.config?

--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -57,7 +57,7 @@ module GettextSetup
     #   Set to true to create a .pot file with only a header
     def self.generate_new_pot(opts = {})
       locales_path = opts[:locales_path] || GettextSetup.locales_path
-      GettextSetup.initialize(locales_path)
+      GettextSetup.initialize_config(locales_path)
       target_path = opts[:target_path] || pot_file_path
       input_files = if opts[:header_only]
                       tmpfile = Tempfile.new('gettext-setup.tmp')
@@ -84,7 +84,7 @@ module GettextSetup
 
     def self.generate_new_po(language, locales_path = GettextSetup.locales_path,
                              pot_file = nil, po_file = nil)
-      GettextSetup.initialize(locales_path)
+      GettextSetup.initialize_config(locales_path)
       language ||= ENV['LANGUAGE']
       pot_file ||= GettextSetup::Pot.pot_file_path
       po_file ||= GettextSetup::Pot.po_file_path(language)
@@ -124,7 +124,7 @@ module GettextSetup
     end
 
     def self.update_pot(locales_path = GettextSetup.locales_path, path = nil)
-      GettextSetup.initialize(locales_path)
+      GettextSetup.initialize_config(locales_path)
       path ||= pot_file_path
 
       if !File.exist? path
@@ -155,7 +155,7 @@ module GettextSetup
     #   The directory for the locales.
     def self.merge(opts = {})
       locales_path = opts[:locales_path] || GettextSetup.locales_path
-      GettextSetup.initialize(locales_path)
+      GettextSetup.initialize_config(locales_path)
       target_filename = GettextSetup.config['project_name'] + '.pot'
       target_path = File.expand_path(target_filename, locales_path)
       oldpot_dir = File.expand_path('oldpot', locales_path)


### PR DESCRIPTION
Prior to this commit the Gettext:Pot module would setup the FastGettext
config and runtime. This would cause strange conflicts with other calls
to FastGettext (for example, when calling the rake task in an
environment that also contains Puppet 5.3.3) so we decided that
since the rake tasks do not require the FastGettext runtime config,
they should not try to set it up.
This commit refactors the GettextSetup.initialize method to call out
to a GettextSetup.initialize_config method, that only configures the
file-related info for the library. Then the GettextSetup:Pot module
is updated to call the GettextSetup.initialized_config method instead
of initialize. As far as I know, the GettextSetup:Pot module is only
called by the rake tasks so hopefully this is a safe fix.