### PR TITLE
(maint) Fix Travis' TargetRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,6 @@ Style/PercentLiteralDelimiters:
 Style/FileName:
   Exclude:
     - 'lib/gettext-setup.rb'
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false


### PR DESCRIPTION
With this absent, Rubocop appears to assume the version running the
test is the minimum ruby version, which is in conflict with what is
defined in the gemspec.