### PR TITLE
(GH-61) Handle initial nil value

### DIFF
--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -11,7 +11,6 @@ module GettextSetup
 
   @config = nil
   @translation_repositories = {}
-  FastGettext.default_available_locales = []
 
   # `locales_path` should include:
   # - config.yaml
@@ -36,9 +35,11 @@ module GettextSetup
     FastGettext.add_text_domain('master_domain', type: :chain, chain: @translation_repositories.values)
     FastGettext.default_text_domain = 'master_domain'
 
-    # Likewise, be explicit in our default language choice.
+    # Likewise, be explicit in our default language choice. Available locales
+    # must be set prior to setting the default_locale since default locale must
+    # available.
+    FastGettext.default_available_locales = (FastGettext.default_available_locales || []) | locales
     FastGettext.default_locale = default_locale
-    FastGettext.default_available_locales = FastGettext.default_available_locales | locales
 
     Locale.set_default(default_locale)
   end

--- a/spec/lib/gettext-setup/gettext_setup_spec.rb
+++ b/spec/lib/gettext-setup/gettext_setup_spec.rb
@@ -10,6 +10,15 @@ describe GettextSetup do
   before(:each) do
     GettextSetup.initialize(locales_path)
   end
+  after(:each) do
+    FastGettext.default_text_domain = nil
+    FastGettext.default_available_locales = nil
+    FastGettext.default_locale = nil
+
+    FastGettext.text_domain = nil
+    FastGettext.available_locales = nil
+    FastGettext.locale = nil
+  end
   let(:config) do
     GettextSetup.config
   end
@@ -79,7 +88,7 @@ describe GettextSetup do
   end
   context 'multiple locales' do
     # locales/ loads the de locale and fixture_locales/ loads the jp locale
-    before(:all) do
+    before(:each) do
       GettextSetup.initialize(fixture_locales_path)
     end
     it 'can aggregate locales across projects' do
@@ -95,7 +104,7 @@ describe GettextSetup do
     end
   end
   context 'translation repository chain' do
-    before(:all) do
+    before(:each) do
       GettextSetup.initialize(fixture_locales_path)
     end
     it 'chain is not nil' do


### PR DESCRIPTION
Previously, if GettextSetup.initialize was called with a config.yaml, but
there were no corresponding language subdirectories, e.g. locales/ja,
then GettextSetup would set FastGettext.default_locale to nil.

The issue was because GettextSetup set FastGettext.default_available_locales
to an empty array in commit bc57b9a. However, FastGettext interpreted that
to mean there were no available locales! So later attempts to set the
FastGettext.default_locale were "filtered out", since the argument was
never one of the available locales.

One subtle issue here was that FastGettext.default_available_locales
defaults to nil. So Array union (`|`), could produce surprising results
the first time the Gettext.initialize method was called:

     $ ruby -e "puts nil | []"
     true

This commit removes the call to `FastGettext.default_available_locales = []`,
protects against calling Array union with nil, and sets the
default_available_locales before setting the default_locale, since the
latter depends on the former. This solves the original issue because
GettextSetup defaults to 'en' even if there are no local subdirectories.
So then that becomes an available locale, and our later attempt to set
the default locale is not filtered out.

This commit also preserves the behavior of INTL-18, which joins locales
across multiple projects, instead of letting the last one overwrite.