### PR TITLE
spec: fix invalid byte-sequence in US-ASCII with ruby2.5 (GH-64)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 Style/Documentation:
   Enabled: false
 
+# see https://github.com/puppetlabs/gettext-setup-gem/pull/65
+Style/Encoding:
+  Enabled: false
+
 # Line length is not useful
 Metrics/LineLength:
   Enabled: false

--- a/spec/lib/gettext-setup/gettext_setup_spec.rb
+++ b/spec/lib/gettext-setup/gettext_setup_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'rspec/expectations'
 require_relative '../../spec_helper'
 


### PR DESCRIPTION
Fixes: https://github.com/puppetlabs/gettext-setup-gem/issues/64

Patch from Hleb Valoshka for Debian
  https://lists.debian.org/debian-ruby/2018/04/msg00034.html
  https://bugs.debian.org/894829