### PR TITLE
(maint) Use new pot if msgcmp unavailable

### DIFF
--- a/lib/gettext-setup/pot.rb
+++ b/lib/gettext-setup/pot.rb
@@ -42,6 +42,12 @@ module GettextSetup
       if status.exitstatus == 1 || /this message is not used/.match(stderr) || /this message is used but not defined/.match(stderr)
         return true
       end
+
+      if stderr =~ /msgcmp: command not found/
+        puts 'Warning - msgcmp is not present on the system'
+        return true
+      end
+
       false
     rescue IOError
       # probably means msgcmp is not present on the system


### PR DESCRIPTION
If msgcamp isn't on the system, we were previously relying on the system
throwing an IOError that we could catch. Unfortunately, this wasn't
consistently happening. This commit adds an additional check to
explicitly print out a warning if msgpack is not available and to
proceed with replacing the old pot with the new one.