### PR TITLE
Add `date` require to metadata_pot.rb

### DIFF
--- a/lib/gettext-setup/metadata_pot.rb
+++ b/lib/gettext-setup/metadata_pot.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'json'
+require 'date'
 
 module GettextSetup
   module MetadataPot


### PR DESCRIPTION
Fixes the following error for Ruby 2.6:
```
uninitialized constant GettextSetup::MetadataPot::DateTime
```