### PR TITLE
Don't depend on a legacy bundler release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 sudo: false
-before_install:
-  - gem install bundler -v 1.10
 script:
   - "bundle exec $CHECK"
 notifications:

--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gettext', '>= 3.0.2'
   spec.add_dependency 'locale'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rspec-core', '~> 3.1'

--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -25,7 +25,7 @@ module GettextSetup
     GettextSetup.initialize_config(locales_path)
 
     # Make the translation methods available everywhere
-    Object.send(:include, FastGettext::Translation)
+    Object.include FastGettext::Translation
 
     # Define our text domain, and set the path into our root.  I would prefer to
     # have something smarter, but we really want this up earlier even than our


### PR DESCRIPTION
It's currently impossible to install dependencies with `bundle
install..` on a modern distribution. bundler 2 is available since more
than a year.