### PR TITLE
(maint) Revert error for some versions of ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,6 @@ Gemspec/RequiredRubyVersion:
   Enabled: false
 Style/SafeNavigation:
   Enabled: false
+
+Lint/SendWithMixinArgument:
+  Enabled: false

--- a/lib/gettext-setup/gettext_setup.rb
+++ b/lib/gettext-setup/gettext_setup.rb
@@ -25,7 +25,7 @@ module GettextSetup
     GettextSetup.initialize_config(locales_path)
 
     # Make the translation methods available everywhere
-    Object.include FastGettext::Translation
+    Object.send(:include, FastGettext::Translation)
 
     # Define our text domain, and set the path into our root.  I would prefer to
     # have something smarter, but we really want this up earlier even than our


### PR DESCRIPTION
A simple rubocop fix caused an error in older versions of ruby. This fix
uses the original `send` command instead.