### PR TITLE
Add Ruby 2.7 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
 rvm:
   - 2.1.9
   - 2.3.3
+  - 2.7.0
 
 env:
   - "CHECK='rspec spec'"

--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.2'
 
-  spec.add_dependency 'fast_gettext', '~> 1.1'
+  spec.add_dependency 'fast_gettext', '>= 1.1.0'
   spec.add_dependency 'gettext', ['>= 3.0.2', '< 3.3.0']
   spec.add_dependency 'locale'
 

--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.2'
 
   spec.add_dependency 'fast_gettext', '>= 1.1.0'
-  spec.add_dependency 'gettext', ['>= 3.0.2', '< 3.3.0']
+  spec.add_dependency 'gettext', '>= 3.0.2'
   spec.add_dependency 'locale'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Ruby 2.7 got released some time ago. Since the first distributions are
shipping it it makes sense to add it to the build matrix.