### PR TITLE
(maint) Relax gettext dependency [DO NOT MERGE]

### DIFF
--- a/gettext-setup.gemspec
+++ b/gettext-setup.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.2'
 
   spec.add_dependency 'fast_gettext', '~> 1.1'
-  spec.add_dependency 'gettext', ['>= 3.0.2', '< 3.3.0']
+  spec.add_dependency 'gettext', ['>= 3.0.2', '~> 3.3']
   spec.add_dependency 'locale'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Commit 2c2ffa60b1a27df54689874283342c8dbbb9b2b7 constrained gettext to
less than 3.3.0 because that version dropped ruby 2.4 and earlier. Now
that we have a 1.0 tag, bump the dependency to allow gettext 3.x (and at
least 3.0.2).