### PR TITLE
(maint) Update CODEOWNERS to include devx

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/razor-maintainers
+* @puppetlabs/devx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/devx
+* @puppetlabs/devx @puppetlabs/razor-maintainers


### PR DESCRIPTION
Prior to this commit the ownership of the repo is the razor team. As this team is no longer an entity, this PR is to update the ownership so that the team can start merging PRs.